### PR TITLE
Server for client and health display

### DIFF
--- a/src/frontend/client_queue.c
+++ b/src/frontend/client_queue.c
@@ -1,0 +1,33 @@
+#include "frontend/client_queue.h"
+#include "frontend/http_constants.h"
+
+int client_queue[QUEUE_SIZE];
+int q_head = 0;
+int q_tail = 0;
+
+pthread_mutex_t q_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t q_cond = PTHREAD_COND_INITIALIZER;
+
+void enqueue_client(int fd) {
+    pthread_mutex_lock(&q_mutex);
+
+    client_queue[q_tail] = fd;
+    q_tail = (q_tail + 1) % QUEUE_SIZE;
+
+    pthread_cond_signal(&q_cond);
+    pthread_mutex_unlock(&q_mutex);
+}
+
+int dequeue_client() {
+    pthread_mutex_lock(&q_mutex);
+
+    while (q_head == q_tail) {
+        pthread_cond_wait(&q_cond, &q_mutex);
+    }
+
+    int fd = client_queue[q_head];
+    q_head = (q_head + 1) % QUEUE_SIZE;
+
+    pthread_mutex_unlock(&q_mutex);
+    return fd;
+}

--- a/src/frontend/client_queue.h
+++ b/src/frontend/client_queue.h
@@ -1,0 +1,18 @@
+#ifndef CLIENT_QUEUE_H
+#define CLIENT_QUEUE_H
+
+#include <pthread.h>
+
+#include "frontend/http_constants.h"
+
+extern int client_queue[QUEUE_SIZE];
+extern int q_head;
+extern int q_tail;
+
+extern pthread_mutex_t q_mutex;
+extern pthread_cond_t q_cond;
+
+void enqueue_client(int fd);
+int dequeue_client();
+
+#endif

--- a/src/frontend/endpoints.c
+++ b/src/frontend/endpoints.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "frontend/http_parser.h"
+
+char* load_file(const char* path, size_t* out_size)
+{
+    FILE* f = fopen(path, "rb");
+    if (!f)
+        return NULL;
+
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+
+    long size = ftell(f);
+    if (size < 0) {
+        fclose(f);
+        return NULL;
+    }
+
+    rewind(f);
+
+    char* buffer = (char*)malloc(size + 1); // +1 for optional '\0'
+    if (!buffer) {
+        fclose(f);
+        return NULL;
+    }
+
+    size_t read = fread(buffer, 1, size, f);
+    fclose(f);
+
+    if (read != (size_t)size) {
+        free(buffer);
+        return NULL;
+    }
+
+    buffer[size] = '\0'; // safe even for binary
+    if (out_size)
+        *out_size = (size_t)size;
+
+    return buffer;
+}
+
+http_response* process_request(http_request* req)
+{
+    if(!req || !req->path)
+        return NULL;
+
+    if(req->method == OPTIONS)
+    {
+        http_response* resp = http_response_init(200, "", 0);
+        if(!resp)
+            return NULL;
+        return resp;
+    }
+
+    str_to_lower((char*)req->path);
+    
+    if(strcmp(req->path, "/health") == 0)
+    {
+        http_response* resp = http_response_init(200, "{\"status\":\"ok\"}", -1);
+        if(!resp)
+            return NULL;
+        http_response_add_header(resp, "Content-Type", "application/json");
+        return resp;
+    }
+
+    if(strcmp(req->path, "/dog.mp4") == 0)
+    {
+        size_t png_size;
+        char* png_data = load_file("dog.mp4", &png_size);
+        if (!png_data)
+        {
+            http_response* resp = http_response_init(500, "Failed to load video.", -1);
+            if(!resp)
+                return NULL;
+            http_response_add_header(resp, "Content-Type", "text/plain");
+            return resp;
+        }
+
+        http_response* resp = http_response_init(200, png_data, png_size);
+        if (!resp) {
+            free(png_data);
+            return NULL;
+        }
+
+        http_response_add_header(resp, "Content-Type", "video/mp4");
+
+        free(png_data);
+        return resp;
+    }
+
+    http_response* resp = http_response_init(404, "Not Found", -1);
+    if(!resp)
+        return NULL;
+    http_response_add_header(resp, "Content-Type", "text/plain");
+    return resp;
+}

--- a/src/frontend/endpoints.h
+++ b/src/frontend/endpoints.h
@@ -1,0 +1,8 @@
+#ifndef ENDPOINTS_H
+#define ENDPOINTS_H
+
+#include "frontend/http_parser.h"
+
+http_response* process_request(http_request* req);
+
+#endif

--- a/src/frontend/frontend_main.c
+++ b/src/frontend/frontend_main.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <unistd.h>
+
+#include "frontend/client_queue.h"
+#include "frontend/http_constants.h"
+#include "frontend/http_main.h"
+#include "libs/jj_log/jj_log.h"
+
+int main() {
+    http_server* srv = http_init();
+    if(!srv)
+        return 1;
+
+    while(1)
+    {
+        int count = http_accept(srv);
+        if(count == 0)
+        {
+            usleep(10000);
+        }
+    }
+
+    http_dispose(&srv);
+
+    return 0;
+}

--- a/src/frontend/http_constants.h
+++ b/src/frontend/http_constants.h
@@ -1,0 +1,18 @@
+#ifndef HTTP_CONSTANTS_H
+#define HTTP_CONSTANTS_H
+
+#define HTTP_PORT 10480  // Port to host HTTP server on
+#define HTTPS_PORT 10480 // Port to host HTTPS (TLS) server on | CURRENTLY UNUSED
+#define LISTENER_COUNT 4 // How many pthreads to start for HTTP connection handling
+
+#define LISTEN_QUEUE 16 // Parameter for listen(), how many connections to queue before refusing
+#define QUEUE_SIZE 32 // Size of client fd queue (circular buffer), set to a higher value for overflow protection
+#define SIGNAL_EXIT -1
+
+#define HTTP_VERSION "HTTP/1.1" // We should support keep-alive
+#define MAX_URL_LEN 256
+#define CORS_ALLOWED_ORIGIN "*"
+#define CORS_ALLOWED_METHODS "GET, OPTIONS"
+#define CORS_ALLOWED_HEADERS "Content-Type"
+
+#endif

--- a/src/frontend/http_main.c
+++ b/src/frontend/http_main.c
@@ -1,0 +1,108 @@
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+
+#include "frontend/client_queue.h"
+#include "frontend/http_constants.h"
+#include "frontend/http_main.h"
+#include "frontend/http_worker.h"
+
+http_server* http_init()
+{
+    int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_fd < 0) {
+        perror("socket");
+        return NULL;
+    }
+
+    int opt = 1;
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    setsockopt(server_fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(tv));
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+
+    addr.sin_family = AF_UNSPEC;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons(HTTP_PORT);
+
+    if (bind(server_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(server_fd);
+        return NULL;
+    }
+
+    if (listen(server_fd, 16) < 0) {
+        perror("listen");
+        close(server_fd);
+        return NULL;
+    }
+
+    http_server* server = calloc(1, sizeof(http_server));
+    if(server == NULL)
+    {
+        printf("Out of memory allocating http_server.\n");
+        return NULL;
+    }
+
+    int flags = fcntl(server_fd, F_GETFL, 0);
+    fcntl(server_fd, F_SETFL, flags | O_NONBLOCK);
+
+    server->server_fd = server_fd;
+
+    printf("Created TCP host on port %d\n", HTTP_PORT);
+
+    for (int i = 0; i < LISTENER_COUNT; i++) {
+        pthread_create(&server->workers[i], NULL, http_worker_thread, NULL);
+    }
+
+    return server;
+}
+
+int http_accept(http_server* server)
+{
+    int accepts = 0;
+    while (1) {
+        int client_fd = accept(server->server_fd, NULL, NULL);
+        if (client_fd >= 0) {
+            enqueue_client(client_fd);
+            accepts++;
+        } else {
+            if(errno == EAGAIN || errno == EWOULDBLOCK) {
+                break;
+            } else {
+                perror("accept");
+            }
+        }
+    }
+    return accepts;
+}
+
+void http_dispose(http_server** server_var)
+{
+    http_server* server = *server_var;
+    close(server->server_fd);
+    
+    int i;
+    for(i = 0; i < LISTENER_COUNT; i++)
+    {
+        enqueue_client(SIGNAL_EXIT);
+    }
+    for(i = 0; i < LISTENER_COUNT; i++)
+    {
+        pthread_join(server->workers[i], NULL);
+    }
+
+    free(server);
+    *server_var = NULL;
+}

--- a/src/frontend/http_main.h
+++ b/src/frontend/http_main.h
@@ -1,0 +1,30 @@
+#ifndef HTTP_MAIN_H
+#define HTTP_MAIN_H
+
+#include <pthread.h>
+
+#include "frontend/http_constants.h"
+
+typedef struct
+{
+    int server_fd;
+    pthread_t workers[LISTENER_COUNT];
+} http_server;
+
+/*
+Starts the HTTP frontend and returns a pointer to a struct representing it.
+Returns NULL if unsuccessful.
+*/
+http_server* http_init();
+
+/*
+Accepts waiting client connections, returns number of clients accepted.
+*/
+int http_accept(http_server* server);
+
+/*
+Close the HTTP frontend and dispose all resources.
+*/
+void http_dispose(http_server** server);
+
+#endif

--- a/src/frontend/http_parser.c
+++ b/src/frontend/http_parser.c
@@ -1,0 +1,415 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libs/linked_list/linked_list.h"
+#include "frontend/http_parser.h"
+#include "frontend/endpoints.h"
+
+char* substr(const char* start, const char* end)
+{
+    return strndup(start, end-start);
+}
+
+RequestMethod Enum_Method(const char* method) {
+    if (!method) return Method_Unknown;
+
+    if (strcmp(method, "GET") == 0) return GET;
+    if (strcmp(method, "POST") == 0) return POST;
+    if (strcmp(method, "PUT") == 0) return PUT;
+    if (strcmp(method, "DELETE") == 0) return DELETE;
+    if (strcmp(method, "PATCH") == 0) return PATCH;
+    if (strcmp(method, "OPTIONS") == 0) return OPTIONS;
+    if (strcmp(method, "HEAD") == 0) return HEAD;
+
+    return Method_Unknown;
+}
+
+ProtocolVersion Enum_Protocol(const char* protocol) {
+    if (!protocol) return Protocol_Unknown;
+
+    if (strcmp(protocol, "HTTP/0.9") == 0) return HTTP_0_9;
+    if (strcmp(protocol, "HTTP/1.0") == 0) return HTTP_1_0;
+    if (strcmp(protocol, "HTTP/1.1") == 0) return HTTP_1_1;
+    if (strcmp(protocol, "HTTP/2.0") == 0) return HTTP_2_0;
+    if (strcmp(protocol, "HTTP/3.0") == 0) return HTTP_3_0;
+
+    return Protocol_Unknown;
+}
+
+const char* RequestMethod_tostring(RequestMethod method) {
+    switch (method) {
+    case GET:
+        return "GET";
+    case POST:
+        return "POST";
+    case PATCH:
+        return "PATCH";
+    case PUT:
+        return "PUT";
+    case DELETE:
+        return "DELETE";
+    case OPTIONS:
+        return "OPTIONS";
+    case HEAD:
+        return "HEAD";
+    default:
+        return "-unknown-";
+    }
+}
+
+const char* CommonResponseMessages(int code) {
+    switch (code) {
+    case 200:
+        return "OK";
+    case 204:
+        return "No Content";
+    case 301:
+        return "Moved Permanently";
+    case 302:
+        return "Found";
+    case 304:
+        return "Not Modified";
+    case 400:
+        return "Bad Request";
+    case 401:
+        return "Unauthorized";
+    case 403:
+        return "Forbidden";
+    case 404:
+        return "Not Found";
+    case 405:
+        return "Method Not Allowed";
+    case 413:
+        return "Content Too Large";
+    case 500:
+        return "Internal Server Error";
+    case 501:
+        return "Not Implemented";
+    case 503:
+        return "Service Unavailable";
+    default:
+        return "";
+    }
+}
+
+void str_to_lower(char *s)
+{
+    if (!s) return;
+    for (; *s; ++s)
+        *s = (char)tolower((unsigned char)*s);
+}
+
+const char* http_get_header(http_request* req, const char* name)
+{
+    char* nameLow = strdup(name);
+    str_to_lower(nameLow);
+    LinkedList_foreach(req->headers, node)
+    {
+        http_header* hdr = (http_header*)node->item;
+        if(strcmp(hdr->Name, nameLow)==0)
+        {
+            free(nameLow);
+            return hdr->Value;
+        }
+    };
+    free(nameLow);
+    return NULL;
+}
+
+http_request* http_parse_request(const char* message) {
+    http_request* request = calloc(1, sizeof(http_request));
+    if(request == NULL)
+        return NULL;
+
+    int state = 0;
+
+    const char* start = message;
+    int finalLoop = 0;
+    while (start && *start && !finalLoop) {
+        // Find end of line
+        const char* end = strstr(start, "\r\n");
+        if (!end) {
+            // No separator found, read to end of message and do not loop again
+            finalLoop = 1;
+            end = message + strlen(message);
+        }
+        // Check length with pointer math
+        int length = end - start;
+        if (length == 0) {
+            // printf("Reached end of request.\n\n");
+            if(state==1)
+            {
+                break;
+            } else {
+                http_request_dispose(&request);
+                return NULL;
+            }
+        }
+        // Allocate memory for current line
+        char* current_line = substr(start, end);
+        if (!current_line) // horrible problem
+        {
+            http_request_dispose(&request);
+            return NULL;
+        }
+
+        if (state == 0) {
+            // Count spaces in request, should match 2
+            int count = 0;
+            char* scan = current_line;
+            for (; *scan; scan++) {
+                if (*scan == ' ') count++;
+            }
+            if (count != 2) {
+                //printf("INVALID: Request is not formatted with 2 spaces.\n\n");
+                free(current_line);
+                http_request_dispose(&request);
+                return NULL;
+            }
+
+            const char* space1 = strchr(current_line, ' ');
+            if(!space1)
+            {
+                free(current_line);
+                http_request_dispose(&request);
+                return NULL;
+            }
+            const char* space2 = strchr(space1 + 1, ' ');
+
+            if (!space2 || space2 <= space1)
+            {
+                //request->reason = Malformed;
+                free(current_line);
+                http_request_dispose(&request);
+                return NULL;
+            }
+            if (space2 - (space1 + 1) >= MAX_URL_LEN) {
+                //printf("INVALID: Request URL is too long\n\n");
+                //request->reason = URLTooLong;
+                free(current_line);
+                http_request_dispose(&request);
+                return NULL;
+            }
+
+            char* method = substr(current_line, space1);
+            if (!method) {
+                free(current_line);
+                http_request_dispose(&request);
+                //request->reason = OutOfMemory;
+                return NULL;
+            }
+            char* path = substr(space1 + 1, space2);
+            if (!path) {
+                free(method);
+                free(current_line);
+                http_request_dispose(&request);
+                //request->reason = OutOfMemory;
+                return NULL;
+            }
+            char* protocol = substr(space2 + 1, current_line + length);
+            if (!protocol) {
+                free(method); free(path);
+                free(current_line);
+                http_request_dispose(&request);
+                //request->reason = OutOfMemory;
+                return NULL;
+            }
+
+            request->method = Enum_Method(method);
+            if(STRICT_VALIDATION && request->method == Method_Unknown)
+            {
+                free(method); free(path); free(protocol);
+                free(current_line);
+                http_request_dispose(&request);
+                //request->reason = InvalidMethod;
+                return NULL;
+            }
+            request->protocol = Enum_Protocol(protocol);
+            if(STRICT_VALIDATION && request->protocol == Protocol_Unknown)
+            {
+                free(method); free(path); free(protocol);
+                free(current_line);
+                http_request_dispose(&request);
+                //request->reason = InvalidProtocol;
+                return NULL;
+            }
+            request->path = path;
+            if(STRICT_VALIDATION && path[0] != '/')
+            {
+                free(method); free(protocol);
+                free(current_line);
+                http_request_dispose(&request);
+                //request->reason = InvalidURL;
+                return NULL;
+            }
+
+            free(method);
+            free(protocol);
+
+            //request->valid = 1;
+            //request->reason = NotInvalid;
+            state = 1; // jump to header parsing
+            request->headers = LinkedList_create();
+            if(request->headers == NULL)
+            {
+                free(current_line);
+                free(request);
+                return NULL;
+            }
+        } else {
+            const char* sep = strstr(current_line, ": ");
+            if (!sep) {
+                //printf("INVALID: Header is malformed.\n\n");
+                free(current_line);
+                http_request_dispose(&request);
+                return NULL;
+            }
+
+            char* name = substr(current_line, sep);
+            if (!name) {
+                free(current_line);
+                http_request_dispose(&request);
+                return NULL;
+            }
+            str_to_lower(name);
+            char* value = substr(sep + 2, current_line + length);
+            if (!value) {
+                free(name);
+                free(current_line);
+                http_request_dispose(&request);
+                return NULL;
+            }
+
+            http_header* header = calloc(1, sizeof(http_header));
+            if (header != NULL) {
+                header->Name = name;
+                header->Value = value;
+                LinkedList_append(request->headers, header);
+            } else {
+                free(name);
+                free(value);
+                free(current_line);
+                http_request_dispose(&request);
+                return NULL;
+            }
+        }
+
+        start = end + 2;
+        free(current_line);
+    }
+
+    return request;
+}
+
+void http_request_dispose(http_request** request_var)
+{
+    if (request_var && *request_var) {
+        http_request* request = *request_var;
+        if(request->path != NULL)
+            free((void*)request->path);
+        if(request->headers != NULL)
+            LinkedList_dispose(&request->headers, http_header_free);
+        free(request);
+        *request_var = NULL;
+    }
+}
+
+void http_header_free(void* header_var) {
+    if(header_var)
+    {
+        http_header* hdr = (http_header*)header_var;
+        free((void*)hdr->Name);
+        free((void*)hdr->Value);
+        free(hdr);
+    }
+}
+
+http_response* http_response_init(int code, const char* body, int bodyLen) {
+    if(!body)
+        return NULL;
+
+    http_response* response = calloc(1, sizeof(http_response));
+    if(!response)
+        return NULL;
+
+    response->headers = LinkedList_create();
+
+    response->responseCode = code;
+    if(bodyLen == -1)
+    {
+        response->body = strdup(body);
+        bodyLen = strlen(response->body);
+    } else {
+        response->body = malloc(bodyLen);
+        memcpy((char*)response->body, body, bodyLen);
+    }
+    response->bodyLen = bodyLen;
+
+    return response;
+}
+
+void http_response_add_header(http_response* response, const char* name, const char* value)
+{
+    if(!response || !name || !value)
+        return;
+    
+    http_header* header = calloc(1, sizeof(http_header));
+    if (header != NULL) {
+        header->Name = strdup(name);
+        header->Value = strdup(value);
+        LinkedList_append(response->headers, header);
+    }
+}
+
+const char* http_response_stringify(http_response* response, size_t* outSize) {
+    const char* message = CommonResponseMessages(response->responseCode);
+    // Count size of everything before allocating
+    // 5 = 2 spaces + response code (3 digits) + null term
+    int messageSize = 5 + strlen(HTTP_VERSION) + strlen(message);
+    if (response->headers != NULL) {
+        char temp[16];
+        snprintf(temp, 16, "%i", response->bodyLen);
+        http_response_add_header(response, "Content-Length", (const char*)temp);
+        LinkedList_foreach(response->headers, node) {
+            http_header* hdr = (http_header*)node->item;
+            messageSize += 4 + strlen(hdr->Name) + strlen(hdr->Value); // 4 = \r\n and symbols between name & value
+        }
+    }
+    messageSize += 4 + response->bodyLen + 1; // 4 = \r\n\r\n
+    // printf("We have to allocate %i bytes.\n",messageSize);
+    char* status = malloc(messageSize);
+    // write first line
+    int curPos = snprintf(status, messageSize, "%s %d %s", HTTP_VERSION, response->responseCode, message);
+    // write headers
+    if (response->headers != NULL) {
+        LinkedList_foreach(response->headers, node) {
+            http_header* hdr = (http_header*)node->item;
+            int written = snprintf(&status[curPos], messageSize - curPos, "\r\n%s: %s", hdr->Name, hdr->Value);
+            curPos += written;
+        }
+    }
+    // write body
+    const uint8_t separator[] = {'\r', '\n', '\r', '\n'};
+    memcpy(&status[curPos], separator, sizeof(separator));
+    curPos += sizeof(separator);
+    if(response->body != NULL)
+        memcpy(&status[curPos], response->body, response->bodyLen);
+    *outSize = messageSize;
+    return status;
+}
+
+void http_response_dispose(http_response** response_var)
+{
+    if (response_var && *response_var) {
+        http_response* response = *response_var;
+        if(response->body != NULL)
+            free((void*)response->body);
+        if(response->headers != NULL)
+            LinkedList_dispose(&response->headers, http_header_free);
+        free(response);
+        *response_var = NULL;
+    }
+}

--- a/src/frontend/http_parser.h
+++ b/src/frontend/http_parser.h
@@ -1,0 +1,71 @@
+#ifndef HTTP_PARSER_H
+#define HTTP_PARSER_H
+
+#include "libs/linked_list/linked_list.h"
+#include "frontend/http_constants.h"
+
+#define STRICT_VALIDATION 1
+
+typedef enum {
+    Method_Unknown = 0,
+
+    GET = 1,
+    POST = 2,
+    PUT = 3,
+    DELETE = 4,
+    PATCH = 5,
+    OPTIONS = 6,
+    HEAD = 7
+} RequestMethod;
+
+typedef enum {
+    Protocol_Unknown = 0,
+
+    HTTP_0_9 = 1,
+    HTTP_1_0 = 2,
+    HTTP_1_1 = 3,
+    HTTP_2_0 = 4,
+    HTTP_3_0 = 5
+} ProtocolVersion;
+
+typedef struct {
+    const char* Name;
+    const char* Value;
+} http_header;
+
+typedef struct
+{
+    RequestMethod method;
+    ProtocolVersion protocol;
+    const char* path;
+    LinkedList* headers;
+} http_request;
+
+typedef struct
+{
+    int responseCode;
+    const char* body;
+    int bodyLen;
+    LinkedList* headers;
+} http_response;
+
+RequestMethod Enum_Method(const char* method);
+ProtocolVersion Enum_Protocol(const char* protocol);
+
+const char* RequestMethod_tostring(RequestMethod method);
+
+void str_to_lower(char *s);
+
+const char* http_get_header(http_request* req, const char* name);
+
+http_request* http_parse_request(const char* message);
+void http_request_dispose(http_request** request_var);
+
+void http_header_free(void* header_var);
+
+http_response* http_response_init(int code, const char* body, int bodyLen);
+void http_response_add_header(http_response* response, const char* name, const char* value);
+const char* http_response_stringify(http_response* response, size_t* outSize);
+void http_response_dispose(http_response** response_var);
+
+#endif

--- a/src/frontend/http_worker.c
+++ b/src/frontend/http_worker.c
@@ -1,0 +1,148 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+#include "frontend/endpoints.h"
+#include "frontend/http_parser.h"
+#include "frontend/client_queue.h"
+#include "frontend/http_constants.h"
+#include "libs/linked_list/linked_list.h"
+
+void* http_worker_thread(void* arg) {
+    (void)arg;
+
+    printf("[Thread-%ld] Ready for connections!\n", pthread_self());
+
+    while (1) {
+        int client_fd = dequeue_client();
+        if(client_fd == SIGNAL_EXIT)
+        {
+            printf("[Thread-%ld] Exit signal received.\n", pthread_self());
+            break;
+        }
+        printf("[Thread-%ld] Client connected (fd=%d)\n",
+               pthread_self(), client_fd);
+
+        char buffer[2048];
+        ssize_t bytes;
+
+        int closeReason = 1;
+
+        size_t total = 0;
+        size_t skip_remaining = 0;
+        while ((bytes = recv(client_fd, buffer + total, sizeof(buffer) - total - 1, 0)) > 0) {
+            total += bytes;
+            buffer[total] = '\0';
+
+            // Skip body
+            if (skip_remaining > 0) {
+                size_t to_discard = bytes;
+                if (to_discard > skip_remaining)
+                    to_discard = skip_remaining;
+
+                skip_remaining -= to_discard;
+
+                // Shift leftover bytes
+                size_t remaining = total - to_discard;
+                memmove(buffer, buffer + to_discard, remaining);
+                total = remaining;
+                buffer[total] = '\0';
+
+                if (skip_remaining > 0)
+                    continue;
+            }
+
+            char* location = strstr(buffer, "\r\n\r\n");
+            if (location && skip_remaining == 0) {
+                http_request* req = http_parse_request(buffer);
+                if (!req)
+                {
+                    printf("[Thread-%ld] Request could not be parsed, likely invalid.\n", pthread_self());
+                    break;
+                }
+
+                size_t header_end_offset = (location - buffer) + 4;
+
+                const char* len = http_get_header(req, "Content-Length");
+                if (len) {
+                    // We received a body that we don't care about, skip it
+                    long content_length = strtoul(len, NULL, 10);
+                    skip_remaining = (size_t)content_length;
+                } else {
+                    skip_remaining = 0;
+                }
+
+                // Consume any body bytes already received
+                size_t body_bytes_read = total - header_end_offset;
+                if (body_bytes_read >= skip_remaining) {
+                    body_bytes_read = skip_remaining;
+                }
+                skip_remaining -= body_bytes_read;
+
+                // Shift remaining bytes down
+                size_t remaining = total - (header_end_offset + body_bytes_read);
+                memmove(buffer, buffer + header_end_offset + body_bytes_read, remaining);
+
+                total = remaining;
+                buffer[total] = '\0';
+
+                // Handle request
+                printf("[Thread-%ld] %s received: %s\n", pthread_self(), RequestMethod_tostring(req->method), req->path);
+                
+                http_response* resp = process_request(req);
+                if(!resp)
+                {
+                    printf("[Thread-%ld] Failed to generate a response, disconnecting client.\n", pthread_self());
+                    break;
+                }
+
+                if(strlen(CORS_ALLOWED_ORIGIN) > 0)
+                    http_response_add_header(resp, "Access-Control-Allow-Origin", CORS_ALLOWED_ORIGIN);
+                if(strlen(CORS_ALLOWED_METHODS) > 0)
+                    http_response_add_header(resp, "Access-Control-Allow-Methods", CORS_ALLOWED_METHODS);
+                if(strlen(CORS_ALLOWED_HEADERS) > 0)
+                    http_response_add_header(resp, "Access-Control-Allow-Headers", CORS_ALLOWED_HEADERS);
+
+                int shouldBreak = 0;
+                const char* hdr = http_get_header(req, "Connection");
+                if(hdr && strcmp(hdr, "close") == 0)
+                {
+                    shouldBreak = 1;
+                    closeReason = 2;
+                } else {
+                    http_response_add_header(resp, "Connection", "keep-alive");
+                }
+
+                size_t response_size = 0;
+                const char* response_str = http_response_stringify(resp, &response_size);
+                
+                send(client_fd, response_str, response_size, 0);
+
+                free((char*)response_str);
+
+                http_request_dispose(&req);
+                http_response_dispose(&resp);
+
+                if(shouldBreak)
+                    break;
+
+                continue;
+            }
+        }
+
+        if(closeReason == 2)
+        {
+            printf("[Thread-%ld] Ending client connection due to requested close. (fd=%d)\n", pthread_self(), client_fd);
+        } else {
+            printf("[Thread-%ld] Ending client connection due to timeout. (fd=%d)\n", pthread_self(), client_fd);
+        }
+
+        close(client_fd);
+    }
+
+    return NULL;
+}

--- a/src/frontend/http_worker.h
+++ b/src/frontend/http_worker.h
@@ -1,0 +1,6 @@
+#ifndef HTTP_WORKER_H
+#define HTTP_WORKER_H
+
+void* http_worker_thread(void* arg);
+
+#endif

--- a/src/libs/linked_list/linked_list.c
+++ b/src/libs/linked_list/linked_list.c
@@ -1,0 +1,151 @@
+#include "linked_list.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+LinkedList *LinkedList_create() {
+  LinkedList *newList =
+      calloc(1, sizeof(LinkedList)); /* zeroed allocation, just what we need */
+  if (!newList) {
+    printf("[LinkedList] Allocation error in LinkedList_create\n");
+    return NULL;
+  }
+  return newList;
+}
+
+Node *LinkedList_get_index(LinkedList *list, size_t index) {
+  if (list == NULL || index >= list->size)
+    return NULL;
+
+  size_t pos = 0;
+  Node *cur = NULL;
+
+  if (index <= list->size / 2) {
+    cur = list->head;
+    while (pos < index) {
+      cur = cur->front;
+      pos++;
+    }
+  } else {
+    cur = list->tail;
+    pos = list->size - 1;
+    while (pos > index) {
+      cur = cur->back;
+      pos--;
+    }
+  }
+  return cur;
+}
+
+int LinkedList_append(LinkedList *list, void *item) {
+  if (list == NULL)
+    return 1;
+  Node *newNode = calloc(1, sizeof(Node));
+  if (newNode == NULL)
+    return 1;
+
+  newNode->item = item;
+  list->size++;
+
+  if (list->tail == NULL) {
+    list->head = newNode;
+  } else {
+    newNode->back = list->tail;
+    list->tail->front = newNode;
+  }
+  list->tail = newNode;
+
+  return 0;
+}
+
+int LinkedList_insert(LinkedList *list, size_t index, void *item) {
+  if (list == NULL)
+    return 1;
+  if (index >= list->size)
+    return LinkedList_append(list, item); /* append fallback */
+  Node *target = LinkedList_get_index(list, index);
+  if (target == NULL)
+    return 1;
+
+  Node *newNode = calloc(1, sizeof(Node));
+  if (newNode == NULL)
+    return 1;
+
+  newNode->item = item;
+  list->size++;
+
+  newNode->back = target->back;
+  newNode->front = target;
+
+  if (target->back != NULL) {
+    target->back->front = newNode;
+  } else {
+    list->head = newNode;
+  }
+  target->back = newNode;
+
+  return 0;
+}
+
+int LinkedList_remove(LinkedList *list, Node *item, void (*free_function)(void *)) {
+  if (list == NULL || item == NULL)
+    return 1;
+
+  Node *back = item->back;
+  Node *front = item->front;
+
+  if (back != NULL) {
+    back->front = front;
+  } else {
+    list->head = front;
+  }
+
+  if (front != NULL) {
+    front->back = back;
+  } else {
+    list->tail = back;
+  }
+
+  list->size--;
+
+  item->back = NULL;
+  item->front = NULL;
+
+  if(free_function != NULL)
+  {
+    free_function(item->item);
+  }
+
+  free(item);
+
+  return 0;
+}
+
+int LinkedList_pop(LinkedList *list, size_t index, void (*free_function)(void *)) {
+  Node *item = LinkedList_get_index(list, index);
+  if (item == NULL)
+    return 1;
+  return LinkedList_remove(list, item, free_function);
+}
+
+void LinkedList_clear(LinkedList *list, void (*free_function)(void *)) {
+  if (list == NULL)
+    return;
+  Node *cur = list->head;
+  while (cur) {
+    Node *next = cur->front;
+    if (free_function != NULL) {
+      free_function(cur->item);
+    }
+    free(cur);
+    cur = next;
+  }
+
+  list->head = NULL;
+  list->tail = NULL;
+  list->size = 0;
+}
+void LinkedList_dispose(LinkedList **list, void (*free_function)(void *)) {
+  LinkedList_clear(*list, free_function);
+  free(*list);
+  *list = NULL;
+}

--- a/src/libs/linked_list/linked_list.h
+++ b/src/libs/linked_list/linked_list.h
@@ -1,0 +1,66 @@
+#ifndef LINKED_LIST_H
+#define LINKED_LIST_H
+
+#include <stddef.h>
+
+typedef struct Node Node;
+struct Node {
+  Node *back;
+  Node *front;
+  void *item;
+};
+
+typedef struct {
+  Node *head;
+  Node *tail;
+  size_t size;
+} LinkedList;
+
+#define LinkedList_foreach(list, node) \
+    for (Node *node = (list)->head; node != NULL; node = node->front)
+
+/* Initializes a new empty LinkedList, and returns the pointer to it */
+LinkedList *LinkedList_create();
+
+/* Returns a pointer to a Node in a LinkedList at a specific index, returns NULL if index does not exist */
+Node *LinkedList_get_index(LinkedList *list, size_t index);
+
+/* Inserts a new item into the LinkedList at a specific index, shifting items after it to the right */
+int LinkedList_insert(LinkedList *list, size_t index, void *item);
+
+/* "Appends" a new item into the LinkedList at the last index */
+int LinkedList_append(LinkedList *list, void *item);
+
+/*
+  Remove a Node from a LinkedList by reference
+    The Node is disposed when removed, you should never attempt to access it again.
+    The stored item is only disposed if free_function is not NULL
+    For basic items, you can use the normal free() function.
+    Example: `LinkedList_remove(list, node, free)`
+*/
+int LinkedList_remove(LinkedList *list, Node *item, void (*free_function)(void *));
+
+/*
+  Remove a Node from a LinkedList by index
+    Follows the same behavior as LinkedList_remove but searches for a Node by index
+*/
+int LinkedList_pop(LinkedList *list, size_t index, void (*free_function)(void *));
+
+/*
+  Remove all nodes from the LinkedList
+    Recommended to send a free_function to properly dispose stored items.
+    For basic items, you can use the normal free() function.
+    Example: `LinkedList_clear(list, free)`
+*/
+void LinkedList_clear(LinkedList *list, void (*free_function)(void *));
+
+/*
+  Dispose entire LinkedList, removing all nodes
+    Recommended to send a free_function to properly dispose stored items.
+    Double pointer is used to prevent dangling pointers, after LinkedList_dispose is called your variable will be set to NULL.
+    For basic items, you can use the normal free() function.
+    Example: `LinkedList_dispose(&list, free)`
+*/
+void LinkedList_dispose(LinkedList **list, void (*free_function)(void *));
+
+#endif


### PR DESCRIPTION
## 🔗 Linked Issue
<!-- Replace X with the actual issue number (e.g., Closes #123) -->
<!-- This will auto-close the issue when the PR is merged -->
Closes #8 

## 📝 Summary
Implements a threaded TCP server in `src/frontend` that communicates in HTTP, supports HTTP/1.1 and keep-alive connections.
Repurposes the HTTP parser from UB-WeatherServer but with critical memory leaks fixed.
Added linked_list from UB-WeatherServer into `libs/linked_list`

Currently does not have a graceful way to shut down in the main function, or any other way to control the config without re-compilation. This is an early PR that we can expand upon in the future. Endpoints are hardcoded (in `endpoints.c`) and don't access any files yet.

Program should be compiled standalone with frontend_main.c as the main code.

## 🚦 Testing Checklist (loop until all pass)
- [x] **Start fresh:** `make clean`
- [x] **Clang-Format:** `make format`
- [ ] **Clang-Tidy:** `make lint` (Solely warnings about printf usage instead of jj_log)
- [x] **Built successfully:** `make debug`
- [ ] **Tests Passed:** `make test` (Unsure how this works)
- [ ] **LLM Review:** `/review_code` workflow passed? (How do you use this?)

## 🏛️ Architectural Decisions
Currently the server has a hardcoded thread count of 4 as opposed to starting up a thread per client connection, we may want to change this to the latter in the future as the server could be vulnerable to a [Slowloris attack](https://www.imperva.com/learn/ddos/slowloris/).