### PR TITLE
Make frontend controllable by global sunspots config

### DIFF
--- a/config/sunspots.json
+++ b/config/sunspots.json
@@ -22,6 +22,21 @@
       "bin_path": "./src/core/TRM",
       "Timer-type": 1,
       "Rel-time": 30
+    },
+    {
+      "name": "Frontend",
+      "bin_path": "./build/debug/src/frontend/sunspots_frontend",
+      "Timer-type": 0,
+      "heartbeat_interval": 5,
+
+      "server_threads": 8,
+      "server_port_http": 10480,
+      "server_port_https": null,
+      "server_listen_queue": 16,
+      "client_queue_size": 32,
+
+      "allow_file_search": true,
+      "file_search_dir": "./htdocs"
     }
   ]
 }

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(sunspots_frontend_core STATIC
   http_main.c
   http_parser.c
   http_worker.c
+  http_constants.c
 )
 target_include_directories(sunspots_frontend_core
   PUBLIC

--- a/src/frontend/client_queue.c
+++ b/src/frontend/client_queue.c
@@ -1,7 +1,7 @@
 #include "client_queue.h"
 #include "http_constants.h"
 
-int client_queue[QUEUE_SIZE];
+int* client_queue;
 int q_head = 0;
 int q_tail = 0;
 int enqueues = 0;

--- a/src/frontend/client_queue.h
+++ b/src/frontend/client_queue.h
@@ -5,7 +5,7 @@
 
 #include "http_constants.h"
 
-extern int client_queue[QUEUE_SIZE];
+extern int* client_queue;
 extern int q_head;
 extern int q_tail;
 

--- a/src/frontend/endpoints.c
+++ b/src/frontend/endpoints.c
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 500
+
 #include <stdio.h>
 #include <unistd.h>
 #include <limits.h>
@@ -62,7 +64,7 @@ int sanitize_path(const char* url_path, char* out_path, size_t out_size)
 
     // Resolve document root
     char doc_root[PATH_MAX];
-    if (!realpath("./htdocs", doc_root))
+    if (!realpath(FILE_SEARCH_DIR, doc_root))
         return -1;
 
     // Build the final path
@@ -116,30 +118,33 @@ http_response* process_request(http_request* req)
 
     // Treat URL as file path
 
-    char file_path[PATH_MAX];
-    if(sanitize_path(req->path, file_path, sizeof(file_path)) == 0)
+    if(ALLOW_SEARCH)
     {
-        size_t file_size;
-        char* file_data = load_file(file_path, &file_size);
-        if (!file_data)
+        char file_path[PATH_MAX];
+        if(sanitize_path(req->path, file_path, sizeof(file_path)) == 0)
         {
-            http_response* resp = http_response_init(404, "Not Found", HTTPRESPONSE_BODYLEN_AUTODETECT);
-            if(!resp)
+            size_t file_size;
+            char* file_data = load_file(file_path, &file_size);
+            if (!file_data)
+            {
+                http_response* resp = http_response_init(404, "Not Found", HTTPRESPONSE_BODYLEN_AUTODETECT);
+                if(!resp)
+                    return NULL;
+                http_response_add_header(resp, "Content-Type", "text/plain");
+                return resp;
+            }
+
+            http_response* resp = http_response_init(200, file_data, file_size);
+            if (!resp) {
+                free(file_data);
                 return NULL;
-            http_response_add_header(resp, "Content-Type", "text/plain");
+            }
+
+            http_response_add_header(resp, "Content-Type", guess_mime_type(file_path));
+
+            free(file_data);
             return resp;
         }
-
-        http_response* resp = http_response_init(200, file_data, file_size);
-        if (!resp) {
-            free(file_data);
-            return NULL;
-        }
-
-        http_response_add_header(resp, "Content-Type", guess_mime_type(file_path));
-
-        free(file_data);
-        return resp;
     }
 
     http_response* resp = http_response_init(404, "Not Found", HTTPRESPONSE_BODYLEN_AUTODETECT);

--- a/src/frontend/frontend_main.c
+++ b/src/frontend/frontend_main.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <syslog.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "client_queue.h"
 #include "http_constants.h"
@@ -38,7 +39,43 @@ int main() {
         exit(EXIT_FAILURE);
     }
     cJSON *cfg           = cJSON_Parse(config_blob);
-    int    hb_interval   = cJSON_GetObjectItem(cfg, "heartbeat_interval")->valueint;
+
+    int hb_interval = 5;
+
+
+    // Load configs safely
+
+    cJSON *js_temp = cJSON_GetObjectItem(cfg, "heartbeat_interval");
+    if(js_temp != NULL) { hb_interval = js_temp->valueint; } else { syslog(LOG_WARNING, "<frontend/frontend_main.c> SUNSPOTS_CONFIG does not contain heartbeat_interval, using default value."); }
+
+    js_temp = cJSON_GetObjectItem(cfg, "server_port_http");
+    if(js_temp != NULL) { HTTP_PORT = js_temp->valueint; } else { syslog(LOG_WARNING, "<frontend/frontend_main.c> SUNSPOTS_CONFIG does not contain server_port_http, using default value."); }
+
+    js_temp = cJSON_GetObjectItem(cfg, "server_threads");
+    if(js_temp != NULL) { LISTENER_COUNT = js_temp->valueint; } else { syslog(LOG_WARNING, "<frontend/frontend_main.c> SUNSPOTS_CONFIG does not contain server_threads, using default value."); }
+
+    js_temp = cJSON_GetObjectItem(cfg, "server_listen_queue");
+    if(js_temp != NULL) { LISTEN_QUEUE = js_temp->valueint; } else { syslog(LOG_WARNING, "<frontend/frontend_main.c> SUNSPOTS_CONFIG does not contain server_listen_queue, using default value."); }
+
+    js_temp = cJSON_GetObjectItem(cfg, "client_queue_size");
+    if(js_temp != NULL) { QUEUE_SIZE = js_temp->valueint; } else { syslog(LOG_WARNING, "<frontend/frontend_main.c> SUNSPOTS_CONFIG does not contain client_queue_size, using default value."); }
+
+    js_temp = cJSON_GetObjectItem(cfg, "allow_file_search");
+    if(js_temp != NULL) { ALLOW_SEARCH = js_temp->valueint; } else { syslog(LOG_WARNING, "<frontend/frontend_main.c> SUNSPOTS_CONFIG does not contain allow_file_search, using default value."); }
+
+    js_temp = cJSON_GetObjectItem(cfg, "file_search_dir");
+    if(js_temp != NULL) {
+        FILE_SEARCH_DIR = malloc(strlen(js_temp->valuestring)+1);
+        if(FILE_SEARCH_DIR == NULL)
+        {
+            syslog(LOG_ERR, "<frontend/frontend_main.c> Memory allocation error for FILE_SEARCH_DIR, exiting.");
+            exit(EXIT_FAILURE);
+        }
+        strcpy(FILE_SEARCH_DIR, js_temp->valuestring);
+    } else {
+        syslog(LOG_WARNING, "<frontend/frontend_main.c> SUNSPOTS_CONFIG does not contain file_search_dir, using default value.");
+        FILE_SEARCH_DIR = "./htdocs";
+    }
 
     if (kill(daemon_pid, sig_number) == -1) {
         printf("Could not signal the daemon PPID\n");

--- a/src/frontend/http_constants.c
+++ b/src/frontend/http_constants.c
@@ -1,0 +1,11 @@
+#include "http_constants.h"
+
+int HTTP_PORT = 10480;  // (server_port_http)    Port to host HTTP server on
+int HTTPS_PORT = 10480; // (server_port_https)   Port to host HTTP server on
+int LISTENER_COUNT = 8; // (server_threads)      How many pthreads to start for HTTP connection handling
+
+int LISTEN_QUEUE = 16;  // (server_listen_queue) Parameter for listen(), how many connections to queue before refusing
+int QUEUE_SIZE = 32;    // (client_queue_size)   Size of client fd queue (circular buffer), set to a higher value for overflow protection
+
+int ALLOW_SEARCH = 1;   // (allow_file_search)   Enables endpoint fallback that treats the request URL as a file path to try and return
+char* FILE_SEARCH_DIR;  // (file_search_dir)     The base path to search through following request URLs, the fallback value is defined in frontend_main.c for safety

--- a/src/frontend/http_constants.h
+++ b/src/frontend/http_constants.h
@@ -1,12 +1,14 @@
 #ifndef HTTP_CONSTANTS_H
 #define HTTP_CONSTANTS_H
 
-#define HTTP_PORT 10480  // Port to host HTTP server on
-#define HTTPS_PORT 10480 // Port to host HTTPS (TLS) server on | CURRENTLY UNUSED
-#define LISTENER_COUNT 8 // How many pthreads to start for HTTP connection handling
+// Defines are static configs, externs are configurable by sunspots.json
 
-#define LISTEN_QUEUE 16 // Parameter for listen(), how many connections to queue before refusing
-#define QUEUE_SIZE 32 // Size of client fd queue (circular buffer), set to a higher value for overflow protection
+extern int HTTP_PORT;
+extern int HTTPS_PORT;
+extern int LISTENER_COUNT;
+
+extern int LISTEN_QUEUE;
+extern int QUEUE_SIZE;
 #define SIGNAL_EXIT -1
 
 #define HTTP_VERSION "HTTP/1.1" // We should support keep-alive
@@ -14,5 +16,8 @@
 #define CORS_ALLOWED_ORIGIN "*"
 #define CORS_ALLOWED_METHODS "GET, OPTIONS"
 #define CORS_ALLOWED_HEADERS "Content-Type"
+
+extern int ALLOW_SEARCH;
+extern char* FILE_SEARCH_DIR;
 
 #endif

--- a/src/frontend/http_main.c
+++ b/src/frontend/http_main.c
@@ -54,6 +54,19 @@ http_server* http_init()
         printf("Out of memory allocating http_server.\n");
         return NULL;
     }
+    server->workers = calloc(LISTENER_COUNT, sizeof(pthread_t));
+    if(server->workers == NULL)
+    {
+        printf("Out of memory allocating http_server->workers.\n");
+        return NULL;
+    }
+
+    client_queue = calloc(QUEUE_SIZE, sizeof(int));
+    if(client_queue == NULL)
+    {
+        printf("Out of memory allocating client_queue.\n");
+        return NULL;
+    }
 
     int flags = fcntl(server_fd, F_GETFL, 0);
     fcntl(server_fd, F_SETFL, flags | O_NONBLOCK);

--- a/src/frontend/http_main.h
+++ b/src/frontend/http_main.h
@@ -8,7 +8,7 @@
 typedef struct
 {
     int server_fd;
-    pthread_t workers[LISTENER_COUNT];
+    pthread_t* workers;
 } http_server;
 
 /*


### PR DESCRIPTION
Title is explanatory, changes from compile-time constants to reading from the global Sunspots config file.